### PR TITLE
Remove unused identifiers flagged in plugin review

### DIFF
--- a/src/note-generator.ts
+++ b/src/note-generator.ts
@@ -49,21 +49,6 @@ function articleVariables(articleGroup: ArticleGroup): Record<string, string> {
 	};
 }
 
-function highlightVariables(highlight: ApiHighlight): Record<string, string> {
-	const date = new Date(highlight.createdAt);
-	return {
-		id: highlight.id,
-		articleId: highlight.articleId,
-		articleTitle: highlight.articleTitle,
-		author: highlight.author,
-		siteName: highlight.siteName,
-		url: highlight.url || "",
-		text: highlight.text,
-		createdAt: highlight.createdAt,
-		date: date.toISOString().split("T")[0],
-	};
-}
-
 export function generateHighlightBlock(highlight: ApiHighlight): string {
 	return `> ${highlight.text}`;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,7 +6,6 @@ import {
 	TFolder,
 } from "obsidian";
 import QuickReadsPlugin from "./main";
-import { DEFAULT_NOTE_TEMPLATE } from "./types";
 
 class FolderSuggest extends AbstractInputSuggest<TFolder> {
 	getSuggestions(query: string): TFolder[] {
@@ -133,7 +132,7 @@ export class QuickReadsSettingTab extends PluginSettingTab {
 
 		// Display last sync time and reset button
 		const lastSync = this.plugin.pluginData.lastSyncTime;
-		const resetSetting = new Setting(containerEl)
+		new Setting(containerEl)
 			.setName("Reset sync")
 			.setDesc(
 				lastSync


### PR DESCRIPTION
- Drop unused highlightVariables helper from note-generator
- Remove unused DEFAULT_NOTE_TEMPLATE import from settings
- Drop unused resetSetting variable assignment