### PR TITLE
Update esbuild to non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"devDependencies": {
 		"@types/node": "^16.11.6",
 		"builtin-modules": "^3.3.0",
-		"esbuild": "0.17.3",
+		"esbuild": "^0.28.0",
 		"obsidian": "latest",
 		"typescript": "4.7.4"
 	}


### PR DESCRIPTION
## Summary
- Bumps esbuild to a version without the known dev-server vulnerability (GHSA-67mh-4wv8-2f99) flagged by `npm audit`.

## Test plan
- [ ] `npm install` completes cleanly
- [ ] `npm run build` succeeds
- [ ] `npm audit` no longer reports the esbuild advisory